### PR TITLE
Clean openlibm, libuv before building

### DIFF
--- a/build_gitwork.sh
+++ b/build_gitwork.sh
@@ -56,13 +56,16 @@ trap upload_log EXIT
 
 # These are the most common failure modes, so clear everything out that we can
 rm -rf deps/libuv deps/Rmath
+rm -f usr/bin/libuv*
+rm -f usr/bin/libsupport*
 rm -f bin/sys*.ji
 git submodule update
 git reset --hard
 git checkout ${JULIA_GIT_BRANCH}
 git fetch
 git reset --hard origin/${JULIA_GIT_BRANCH}
-make cleanall
+make -C deps clean-openlibm
+make -j1 cleanall
 
 # Find the last commit that passed a Travis build
 set +e


### PR DESCRIPTION
This should ultimately be handled better at the Makefile level I guess, but this is what I'm using right now.
